### PR TITLE
feat: Helm 차트에 latest 태그 추가

### DIFF
--- a/.github/workflows/unified-artifact-push.yaml
+++ b/.github/workflows/unified-artifact-push.yaml
@@ -171,9 +171,16 @@ jobs:
 
       - name: Push (OCI)
         run: |
+          # 버전 태그로 푸시
           helm push "${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz" \
             oci://docker.io/${{ secrets.DOCKERHUB_USERNAME }}
-          echo "::notice title=Done::${{ env.CHART_NAME }} v${{ env.CHART_VERSION }} 푸시 완료"
+          echo "::notice title=Version Push::${{ env.CHART_NAME }} v${{ env.CHART_VERSION }} 푸시 완료"
+          
+          # latest 태그로 추가 푸시
+          cp "${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz" "${{ env.CHART_NAME }}-latest.tgz"
+          helm push "${{ env.CHART_NAME }}-latest.tgz" \
+            oci://docker.io/${{ secrets.DOCKERHUB_USERNAME }}
+          echo "::notice title=Latest Push::${{ env.CHART_NAME }} latest 태그 푸시 완료"
 
   build-and-push-docker:
     needs: detect-artifacts


### PR DESCRIPTION
## Summary
- Helm OCI 레지스트리에 차트를 푸시할 때 버전 태그와 함께 latest 태그도 추가합니다
- 사용자가 `helm pull oci://... --version latest` 명령을 사용할 수 있도록 개선합니다

## 변경사항
- `unified-artifact-push.yaml` 워크플로우 수정
  - 기존 버전 태그로 푸시한 후 동일한 차트를 latest 태그로도 추가 푸시
  - 파일명을 `{chart-name}-latest.tgz`로 복사하여 latest 버전으로 푸시

## 사용 예시
변경 후 아래와 같이 latest 태그로 차트를 pull 할 수 있습니다:
```bash
helm pull oci://docker.io/username/chart-name --version latest
```

🤖 Generated with [Claude Code](https://claude.ai/code)