### PR TITLE
feat: GitHub Actions 실패 시 Slack 알림 기능 추가

### DIFF
--- a/.github/workflows/slack-notifications.yaml
+++ b/.github/workflows/slack-notifications.yaml
@@ -1,0 +1,57 @@
+name: Slack Notifications
+
+on:
+  workflow_run:
+    workflows: 
+      - "Unified Artifact Push"
+      - "Update Casdoor"
+      - "Update Code-Server"
+    types:
+      - completed
+
+jobs:
+  notify-failure:
+    name: Send Slack Notification
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      secrets.SLACK_WEBHOOK_URL != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          # 실패한 워크플로우 정보
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+          WORKFLOW_URL="${{ github.event.workflow_run.html_url }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          ACTOR="${{ github.event.workflow_run.actor.login }}"
+          
+          # Slack 메시지 전송
+          curl -X POST -H 'Content-type: application/json' \
+          --data "{
+            \"text\": \"❌ GitHub Actions 실패 알림\",
+            \"blocks\": [
+              {
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"*워크플로우:* ${WORKFLOW_NAME}\n*브랜치:* ${BRANCH}\n*실행자:* ${ACTOR}\"
+                }
+              },
+              {
+                \"type\": \"actions\",
+                \"elements\": [
+                  {
+                    \"type\": \"button\",
+                    \"text\": {
+                      \"type\": \"plain_text\",
+                      \"text\": \"🔍 실패 내용 확인\"
+                    },
+                    \"url\": \"${WORKFLOW_URL}\"
+                  }
+                ]
+              }
+            ]
+          }" \
+          ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
## 개요
GitHub Actions 워크플로우가 실패할 때 Slack으로 알림을 보내는 기능을 추가합니다.

## 변경사항
- 새로운 워크플로우 파일 추가: `.github/workflows/slack-notifications.yaml`
- 모든 브랜치의 워크플로우 실패를 감지
- 기존 워크플로우 수정 없이 독립적으로 작동

## 특징
- **모니터링 대상**: 
  - Unified Artifact Push
  - Update Casdoor
  - Update Code-Server
- **알림 내용**:
  - 실패한 워크플로우 이름
  - 브랜치 정보
  - 실행자 정보
  - GitHub Actions 페이지 직접 링크
- **조건부 실행**: `SLACK_WEBHOOK_URL` 시크릿이 설정된 경우에만 작동

## 테스트
이 PR이 머지되면 `SLACK_WEBHOOK_URL` 시크릿을 설정한 후, 의도적으로 워크플로우를 실패시켜 알림이 제대로 작동하는지 확인할 수 있습니다.

## 추가 작업
- [ ] `SLACK_WEBHOOK_URL` 시크릿 설정 필요
- [ ] 알림 작동 테스트