### PR TITLE
fix: Slack Notifications 워크플로우 startup_failure 수정

### DIFF
--- a/.github/workflows/slack-notifications.yaml
+++ b/.github/workflows/slack-notifications.yaml
@@ -12,9 +12,7 @@ on:
 jobs:
   notify-failure:
     name: Send Slack Notification
-    if: |
-      github.event.workflow_run.conclusion == 'failure' &&
-      secrets.SLACK_WEBHOOK_URL != ''
+    if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Message


### PR DESCRIPTION
## 문제 상황
Slack Notifications 워크플로우가 `startup_failure`로 실패하여 알림이 전송되지 않음

## 원인 분석
- GitHub Actions에서 `secrets` 컨텍스트를 `if` 조건문에서 직접 평가할 수 없음
- `secrets.SLACK_WEBHOOK_URL \!= ''` 조건이 파싱 단계에서 오류 발생

## 해결 방법
- `secrets.SLACK_WEBHOOK_URL \!= ''` 조건 제거
- `github.event.workflow_run.conclusion == 'failure'` 조건만 유지
- SLACK_WEBHOOK_URL은 항상 설정되어 있다고 가정

## 변경사항
- `.github/workflows/slack-notifications.yaml` 파일의 조건문 단순화

🤖 Generated with [Claude Code](https://claude.ai/code)