### PR TITLE
fix: allow KEDA minReplicaCount to be set to 0

### DIFF
--- a/helm-charts/quick-deploy/Chart.yaml
+++ b/helm-charts/quick-deploy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Rapid multi-application deployment template for Kubernetes
 name: quick-deploy
 type: application
-version: 0.1.5
+version: 0.1.6
 keywords:
   - deployment
   - multi-app

--- a/helm-charts/quick-deploy/templates/scaledobject.yaml
+++ b/helm-charts/quick-deploy/templates/scaledobject.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: {{ include "quick-deploy.fullname" (dict "root" $ "name" $name "app" $app) }}
-  minReplicaCount: {{ $app.keda.minReplicaCount | default 1 }}
+  minReplicaCount: {{ if hasKey $app.keda "minReplicaCount" }}{{ $app.keda.minReplicaCount }}{{ else }}1{{ end }}
   maxReplicaCount: {{ $app.keda.maxReplicaCount | default 10 }}
   {{- with $app.keda.pollingInterval }}
   pollingInterval: {{ . }}


### PR DESCRIPTION
## Summary
- Fixed an issue where KEDA's minReplicaCount couldn't be set to 0
- Changed from using Helm's `default` filter to explicit `hasKey` check
- Bumped Chart version from 0.1.5 to 0.1.6

## Problem
The previous implementation used `{{ $app.keda.minReplicaCount | default 1 }}`, which treats `0` as a falsy value and replaces it with the default value of `1`. This prevented users from setting minReplicaCount to 0, which is a valid configuration for KEDA when you want to scale down to zero replicas.

## Solution
Changed to use `{{ if hasKey $app.keda "minReplicaCount" }}{{ $app.keda.minReplicaCount }}{{ else }}1{{ end }}` which:
- Explicitly checks if the key exists in the configuration
- Uses the actual value if present (including 0)
- Falls back to 1 only if the key is not defined

## Test plan
- [ ] Deploy with minReplicaCount: 0 and verify KEDA ScaledObject accepts the value
- [ ] Deploy without minReplicaCount defined and verify it defaults to 1
- [ ] Deploy with minReplicaCount: 3 and verify it uses the specified value

🤖 Generated with [Claude Code](https://claude.ai/code)