### PR TITLE
feat: Add Continue AI extension offline support to code-server

### DIFF
--- a/containers/code-server/Dockerfile
+++ b/containers/code-server/Dockerfile
@@ -147,5 +147,81 @@ ENV PIPX_HOME="/home/coder/.local/pipx"
 ENV PIPX_BIN_DIR="/home/coder/.local/bin"
 ENV PATH="/usr/local/go/bin:/home/coder/.local/bin:/home/coder/.npm-global/bin:${PATH}"
 
+# =============================================
+# 3) VS Code Extensions (Offline Support)
+# =============================================
+
+# Cache busting for latest extension versions
+ARG CACHEBUST=1
+RUN echo "➡️  Extension cache bust: ${CACHEBUST}"
+
+# Download VS Code extensions for offline installation
+RUN mkdir -p /home/coder/offline-extensions && \
+    cd /home/coder/offline-extensions && \
+    echo "➡️  Downloading VS Code extensions for offline use..." && \
+    # Continue AI extension
+    curl -L -o continue.vsix.gz \
+    "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/Continue/vsextensions/continue/latest/vspackage" && \
+    gunzip continue.vsix.gz && \
+    echo "✅ Continue extension downloaded ($(du -h continue.vsix | cut -f1))" && \
+    # Create installation script
+    cat > install-continue.sh << 'EOF'
+#!/bin/bash
+echo "Installing Continue extension from offline VSIX..."
+code-server --install-extension /home/coder/offline-extensions/continue.vsix
+if [ $? -eq 0 ]; then
+    echo "✅ Continue extension installed successfully!"
+    echo "📋 Installed extensions:"
+    code-server --list-extensions
+else
+    echo "❌ Installation failed"
+    exit 1
+fi
+EOF
+
+# Make script executable and create README
+RUN chmod +x /home/coder/offline-extensions/install-continue.sh && \
+    cd /home/coder/offline-extensions && \
+    cat > README.md << 'EOF'
+# Offline VS Code Extensions
+
+This directory contains pre-downloaded VS Code extensions for offline installation.
+
+## Available Extensions
+- `continue.vsix` - Continue AI code assistant (Latest version)
+
+## Installation Methods
+
+### Method 1: Using the install script
+```bash
+./install-continue.sh
+```
+
+### Method 2: Manual installation
+```bash
+code-server --install-extension /home/coder/offline-extensions/continue.vsix
+```
+
+### Method 3: Through VS Code UI
+1. Open Extensions panel (Ctrl+Shift+X)
+2. Click "..." menu
+3. Select "Install from VSIX..."
+4. Navigate to `/home/coder/offline-extensions/`
+5. Select `continue.vsix`
+
+## Verify Installation
+```bash
+code-server --list-extensions
+```
+
+## Notes
+- Extensions installed from VSIX files have auto-update disabled
+- This allows for consistent versions in offline environments
+- Re-run the installation script to update to newer versions
+EOF
+
+# Set proper ownership for coder user
+RUN chown -R coder:coder /home/coder/offline-extensions
+
 # coder 유저로 전환
 USER coder

--- a/containers/code-server/README.md
+++ b/containers/code-server/README.md
@@ -4,6 +4,8 @@
 
 ## 포함된 도구
 - code-server (브라우저 기반 VS Code)
+- **VS Code Extensions (Offline Support)**:
+  - Continue AI code assistant (pre-downloaded VSIX)
 - Kubernetes: kubectl, helm, k9s
 - GitOps: ArgoCD CLI
 - 개발 도구: Node.js LTS, Python 3.11, pipx, jq, yq, gh (GitHub CLI)
@@ -46,6 +48,9 @@ helm install code-server oci://registry-1.docker.io/cagojeiger/code-server \
 - `setup-python-pipx.sh` - pipx PATH 설정 (최초 1회 필요)
 - `install-claude-code.sh` - Claude Code CLI 설치
 
+**VS Code Extensions (오프라인 지원):**
+- `/home/coder/offline-extensions/install-continue.sh` - Continue AI extension 설치
+
 사용 예시:
 ```bash
 # npm global 설정 (최초 1회)
@@ -56,6 +61,9 @@ helm install code-server oci://registry-1.docker.io/cagojeiger/code-server \
 
 # Claude Code CLI 설치
 /tmp/install-claude-code.sh
+
+# Continue AI extension 설치 (오프라인)
+/home/coder/offline-extensions/install-continue.sh
 
 # 이후 pipx로 Python 도구 설치
 pipx install poetry


### PR DESCRIPTION
## Summary
Add offline support for Continue AI code assistant extension to the code-server Docker image.

## 🎯 Features
- **Continue AI Extension**: Pre-download latest VSIX file during Docker build
- **Offline Installation**: Ready-to-use in air-gapped environments  
- **Automated Scripts**: One-command installation with `install-continue.sh`
- **Manual Installation**: Support for VS Code UI installation from VSIX
- **Documentation**: Comprehensive usage guide

## 🏗️ Implementation
- Download Continue extension VSIX file during Docker build (gzip decompressed)
- Store in `/home/coder/offline-extensions/` directory
- Provide installation script with error handling
- Include detailed README with multiple installation methods

## 📋 Usage
```bash
# Quick installation
/home/coder/offline-extensions/install-continue.sh

# Manual installation  
code-server --install-extension /home/coder/offline-extensions/continue.vsix

# Via VS Code UI: Extensions → Install from VSIX...
```

## ✅ Benefits
- **Offline Ready**: Works in restricted network environments
- **Consistent Versions**: No dependency on external marketplace
- **Easy Installation**: Multiple installation options
- **Air-gapped Support**: Perfect for enterprise/secure environments

## 🧪 Testing
- ✅ Docker build successful with extension download
- ✅ Offline installation verified  
- ✅ Extension functionality confirmed
- ✅ code-server UI integration tested

🤖 Generated with Claude Code