### PR TITLE
feat: quick-cronjob Helm chart for CronJob management

### DIFF
--- a/helm-charts/quick-cronjob/.helmignore
+++ b/helm-charts/quick-cronjob/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/quick-cronjob/Chart.yaml
+++ b/helm-charts/quick-cronjob/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: quick-cronjob
+description: Rapid multi-cronjob deployment template for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - cronjob
+  - multi-job
+  - rapid
+  - template
+maintainers:
+  - name: cagojeiger
+    email: cagojeiger@example.com
+sources:
+  - https://github.com/cagojeiger/auto-action

--- a/helm-charts/quick-cronjob/templates/_helpers.tpl
+++ b/helm-charts/quick-cronjob/templates/_helpers.tpl
@@ -1,0 +1,141 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "quick-cronjob.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "quick-cronjob.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "quick-cronjob.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "quick-cronjob.labels" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+helm.sh/chart: {{ include "quick-cronjob.chart" $root }}
+app.kubernetes.io/name: {{ include "quick-cronjob.name" $root }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}
+{{- if $name }}
+app.kubernetes.io/component: {{ $name }}
+{{- end }}
+{{- if $root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ $root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ $root.Release.Service }}
+{{- end }}
+
+{{/*
+Full name for a job
+*/}}
+{{- define "quick-cronjob.jobFullname" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- printf "%s-%s" $root.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+ServiceAccount name for a job
+*/}}
+{{- define "quick-cronjob.serviceAccountName" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $job := .job -}}
+{{- if and $job.serviceAccount $job.serviceAccount.name -}}
+{{- $job.serviceAccount.name -}}
+{{- else -}}
+{{- include "quick-cronjob.jobFullname" (dict "root" $root "name" $name) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ConfigMap name for a job
+*/}}
+{{- define "quick-cronjob.configMapName" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $job := .job -}}
+{{- if and $job.configMap $job.configMap.name -}}
+{{- $job.configMap.name -}}
+{{- else -}}
+{{- printf "%s-config" (include "quick-cronjob.jobFullname" (dict "root" $root "name" $name)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+PVC name for a job
+*/}}
+{{- define "quick-cronjob.pvcName" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $job := .job -}}
+{{- if and $job.persistence $job.persistence.name -}}
+{{- $job.persistence.name -}}
+{{- else if and $job.persistence $job.persistence.existingClaim -}}
+{{- $job.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-pvc" (include "quick-cronjob.jobFullname" (dict "root" $root "name" $name)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "quick-cronjob.serviceAccount" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "quick-cronjob.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image name for a job
+*/}}
+{{- define "quick-cronjob.image" -}}
+{{- $root := .root -}}
+{{- $job := .job -}}
+{{- $registry := "" -}}
+{{- if $root.Values.global.imageRegistry -}}
+{{- $registry = printf "%s/" $root.Values.global.imageRegistry -}}
+{{- end -}}
+{{- printf "%s%s:%s" $registry $job.image.repository $job.image.tag -}}
+{{- end -}}
+
+{{/*
+Timezone for a job
+*/}}
+{{- define "quick-cronjob.timeZone" -}}
+{{- $root := .root -}}
+{{- $job := .job -}}
+{{- if $job.timeZone -}}
+{{- $job.timeZone -}}
+{{- else if $root.Values.global.timezone -}}
+{{- $root.Values.global.timezone -}}
+{{- else -}}
+{{- "UTC" -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/quick-cronjob/templates/clusterrole.yaml
+++ b/helm-charts/quick-cronjob/templates/clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if or (not (hasKey $job "enabled")) $job.enabled }}
+{{- if or (and $job.clusterAdmin $job.clusterAdmin.enabled) (and $job.clusterRole $job.clusterRole.create) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}-cluster-role
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+rules:
+{{- if and $job.clusterAdmin $job.clusterAdmin.enabled }}
+  # Cluster admin permissions
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+{{- else if $job.clusterRole.rules }}
+  # Custom cluster role rules
+  {{- toYaml $job.clusterRole.rules | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/clusterrolebinding.yaml
+++ b/helm-charts/quick-cronjob/templates/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if or (not (hasKey $job "enabled")) $job.enabled }}
+{{- if or (and $job.clusterAdmin $job.clusterAdmin.enabled) (and $job.clusterRole $job.clusterRole.create) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}-cluster-binding
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "quick-cronjob.serviceAccountName" (dict "root" $ "name" $name "job" $job) }}
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/configmap.yaml
+++ b/helm-charts/quick-cronjob/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if and (or (not (hasKey $job "enabled")) $job.enabled) $job.configMap.create }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "quick-cronjob.configMapName" (dict "root" $ "name" $name "job" $job) }}
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+data:
+  {{- range $key, $value := $job.configMap.data }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/cronjob.yaml
+++ b/helm-charts/quick-cronjob/templates/cronjob.yaml
@@ -1,0 +1,175 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if or (not (hasKey $job "enabled")) $job.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+spec:
+  schedule: {{ $job.schedule | quote }}
+  {{- if $job.timeZone }}
+  timeZone: {{ include "quick-cronjob.timeZone" (dict "root" $ "job" $job) }}
+  {{- end }}
+  {{- if hasKey $job "suspend" }}
+  suspend: {{ $job.suspend }}
+  {{- end }}
+  {{- if $job.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ $job.startingDeadlineSeconds }}
+  {{- end }}
+  concurrencyPolicy: {{ $job.concurrencyPolicy | default "Forbid" }}
+  successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit | default 1 }}
+  jobTemplate:
+    spec:
+      {{- if $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
+      {{- end }}
+      {{- if $job.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ $job.ttlSecondsAfterFinished }}
+      {{- end }}
+      {{- if $job.backoffLimit }}
+      backoffLimit: {{ $job.backoffLimit }}
+      {{- end }}
+      {{- if $job.completions }}
+      completions: {{ $job.completions }}
+      {{- end }}
+      {{- if $job.parallelism }}
+      parallelism: {{ $job.parallelism }}
+      {{- end }}
+      template:
+        metadata:
+          labels:
+            {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 12 }}
+          {{- with $job.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          restartPolicy: {{ $job.restartPolicy | default "OnFailure" }}
+
+          {{- if or (and $job.serviceAccount $job.serviceAccount.create) $.Values.global.imagePullSecrets $job.imagePullSecrets }}
+          {{- if and $job.serviceAccount $job.serviceAccount.create }}
+          serviceAccountName: {{ include "quick-cronjob.serviceAccountName" (dict "root" $ "name" $name "job" $job) }}
+          {{- end }}
+          {{- end }}
+
+          {{- with (coalesce $job.imagePullSecrets $.Values.global.imagePullSecrets) }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- if $job.initContainers }}
+          initContainers:
+            {{- toYaml $job.initContainers | nindent 12 }}
+          {{- end }}
+
+          containers:
+          - name: {{ $name }}
+            image: {{ include "quick-cronjob.image" (dict "root" $ "job" $job) }}
+            imagePullPolicy: {{ $job.image.pullPolicy | default "IfNotPresent" }}
+
+            {{- with $job.command }}
+            command:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- with $job.args }}
+            args:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- if or $job.env $job.envFrom }}
+            {{- with $job.env }}
+            env:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- with $job.envFrom }}
+            envFrom:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- end }}
+
+            {{- with $job.resources }}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- if or $job.volumeMounts $job.configMap.create (and $job.persistence $job.persistence.enabled) }}
+            volumeMounts:
+            {{- if $job.configMap.create }}
+            - name: config
+              mountPath: /scripts
+              readOnly: true
+            {{- end }}
+            {{- if and $job.persistence $job.persistence.enabled }}
+            - name: data
+              mountPath: {{ $job.persistence.mountPath | default "/data" }}
+            {{- end }}
+            {{- with $job.volumeMounts }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- end }}
+
+            {{- with $job.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- with $job.livenessProbe }}
+            livenessProbe:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+            {{- with $job.readinessProbe }}
+            readinessProbe:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+          {{- if $job.sidecars }}
+          {{- with $job.sidecars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+
+          {{- if or $job.volumes $job.configMap.create (and $job.persistence $job.persistence.enabled) }}
+          volumes:
+          {{- if $job.configMap.create }}
+          - name: config
+            configMap:
+              name: {{ include "quick-cronjob.configMapName" (dict "root" $ "name" $name "job" $job) }}
+              defaultMode: 0755
+          {{- end }}
+          {{- if and $job.persistence $job.persistence.enabled }}
+          - name: data
+            persistentVolumeClaim:
+              claimName: {{ include "quick-cronjob.pvcName" (dict "root" $ "name" $name "job" $job) }}
+          {{- end }}
+          {{- with $job.volumes }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+
+          {{- with $job.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with $job.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with $job.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with $job.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/deployment.yaml
+++ b/helm-charts/quick-cronjob/templates/deployment.yaml
@@ -1,0 +1,193 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if and (or (not (hasKey $job "enabled")) $job.enabled) $job.testDeployment.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}-test
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+    app.kubernetes.io/component: test-deployment
+  annotations:
+    description: "Test deployment for {{ $name }} cronjob. Use kubectl exec to access."
+spec:
+  replicas: {{ $job.testDeployment.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "quick-cronjob.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      cronjob: {{ $name }}
+      mode: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "quick-cronjob.name" $ }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        cronjob: {{ $name }}
+        mode: test
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        kubectl.kubernetes.io/default-container: {{ $name }}
+        {{- with $job.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if or (and $job.serviceAccount $job.serviceAccount.create) $.Values.global.imagePullSecrets $job.imagePullSecrets }}
+      {{- if and $job.serviceAccount $job.serviceAccount.create }}
+      serviceAccountName: {{ include "quick-cronjob.serviceAccountName" (dict "root" $ "name" $name "job" $job) }}
+      {{- end }}
+      {{- end }}
+
+      {{- with (coalesce $job.imagePullSecrets $.Values.global.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- if $job.initContainers }}
+      initContainers:
+        {{- toYaml $job.initContainers | nindent 8 }}
+      {{- end }}
+
+      containers:
+      - name: {{ $name }}
+        image: {{ include "quick-cronjob.image" (dict "root" $ "job" $job) }}
+        imagePullPolicy: {{ $job.image.pullPolicy | default "IfNotPresent" }}
+
+        # Sleep container with welcome message
+        command: ["/bin/bash"]
+        args:
+          - -c
+          - |
+            echo "🚀 Quick-CronJob Test Environment Ready!"
+            echo "📝 Original CronJob command available in /scripts/"
+            echo "🔗 Access: kubectl exec -it deploy/{{ include "quick-cronjob.jobFullname" (dict "root" $ "name" $name) }}-test -- bash"
+            echo ""
+            while true; do sleep 86400; done
+
+        # Environment variables (same as CronJob)
+        {{- if or $job.env $job.envFrom }}
+        {{- with $job.env }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with $job.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+
+        # Resources (development-friendly defaults)
+        resources:
+          {{- if $job.resources }}
+          {{- toYaml $job.resources | nindent 10 }}
+          {{- else }}
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+          {{- end }}
+
+        # Volume mounts (same as CronJob)
+        {{- if or $job.volumeMounts $job.configMap.create (and $job.persistence $job.persistence.enabled) }}
+        volumeMounts:
+        {{- if $job.configMap.create }}
+        - name: config
+          mountPath: /scripts
+          readOnly: false  # Allow editing scripts for testing
+        {{- end }}
+        {{- if and $job.persistence $job.persistence.enabled }}
+        - name: data
+          mountPath: {{ $job.persistence.mountPath | default "/data" }}
+        {{- end }}
+        - name: workspace
+          mountPath: /workspace
+        {{- with $job.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- else }}
+        volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+        {{- end }}
+
+        # Security context (same as CronJob)
+        {{- with $job.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        # Working directory
+        workingDir: /workspace
+
+        # Enable TTY for better shell experience
+        tty: true
+        stdin: true
+
+        # Health checks
+        livenessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "true"]
+          periodSeconds: 60
+          timeoutSeconds: 5
+
+        readinessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "true"]
+          initialDelaySeconds: 5
+          periodSeconds: 30
+
+      {{- if $job.sidecars }}
+      # Sidecar containers (same as CronJob)
+      {{- with $job.sidecars }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+
+      # Volumes (same as CronJob + workspace)
+      volumes:
+      {{- if $job.configMap.create }}
+      - name: config
+        configMap:
+          name: {{ include "quick-cronjob.configMapName" (dict "root" $ "name" $name "job" $job) }}
+          defaultMode: 0755
+      {{- end }}
+      {{- if and $job.persistence $job.persistence.enabled }}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "quick-cronjob.pvcName" (dict "root" $ "name" $name "job" $job) }}
+      {{- end }}
+      - name: workspace
+        emptyDir: {}
+      {{- with $job.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Node configuration (same as CronJob)
+      {{- with $job.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with $job.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with $job.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Pod security context (same as CronJob)
+      {{- with $job.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      # Restart policy for development
+      restartPolicy: Always
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/pvc.yaml
+++ b/helm-charts/quick-cronjob/templates/pvc.yaml
@@ -1,0 +1,39 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if and (or (not (hasKey $job "enabled")) $job.enabled) (and $job.persistence $job.persistence.enabled) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "quick-cronjob.pvcName" (dict "root" $ "name" $name "job" $job) }}
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- with $job.persistence.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ $job.persistence.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ $job.persistence.size }}
+  {{- $storageClass := "" }}
+  {{- if $job.persistence.storageClassName }}
+    {{- $storageClass = $job.persistence.storageClassName }}
+  {{- else if $.Values.global.storageClass }}
+    {{- $storageClass = $.Values.global.storageClass }}
+  {{- end }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
+  {{- end }}
+  {{- with $job.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $job.persistence.dataSource }}
+  dataSource:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/templates/serviceaccount.yaml
+++ b/helm-charts/quick-cronjob/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- range $name, $job := .Values.jobs }}
+{{- if and (or (not (hasKey $job "enabled")) $job.enabled) (and $job.serviceAccount $job.serviceAccount.create) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "quick-cronjob.serviceAccountName" (dict "root" $ "name" $name "job" $job) }}
+  labels:
+    {{- include "quick-cronjob.labels" (dict "root" $ "name" $name) | nindent 4 }}
+  {{- with $job.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ $job.serviceAccount.automount | default true }}
+{{- if $job.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml $job.serviceAccount.imagePullSecrets | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/quick-cronjob/values.yaml
+++ b/helm-charts/quick-cronjob/values.yaml
@@ -1,0 +1,159 @@
+# Default values for quick-cronjob
+# This provides a test environment with Ubuntu 22.04
+
+########################################################
+# Global Configuration
+########################################################
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+  timezone: "UTC"
+  storageClass: ""
+
+########################################################
+# CronJobs
+########################################################
+# 기본적으로 Ubuntu 22.04 테스트 환경 제공
+jobs:
+  # 테스트/개발용 기본 환경
+  test-environment:
+    enabled: true
+
+    # CronJob 설정 (실제로는 실행되지 않음)
+    schedule: "0 0 31 2 *"  # 2월 31일 = 절대 실행 안됨
+    suspend: true  # CronJob 일시 중지
+    timeZone: "UTC"
+
+    # Ubuntu 22.04 이미지
+    image:
+      repository: ubuntu
+      tag: "22.04"
+      pullPolicy: IfNotPresent
+
+    # 기본 명령 (CronJob용 - 실제로는 실행 안됨)
+    command: ["/bin/bash"]
+    args: ["-c", "echo 'Test environment ready'"]
+
+    # 환경변수
+    env:
+      - name: TEST_MODE
+        value: "true"
+      - name: ENVIRONMENT
+        value: "development"
+
+    # ConfigMap - 유용한 스크립트 제공
+    configMap:
+      create: true
+      data:
+        README.md: |
+          # Quick-CronJob Test Environment
+
+          Ubuntu 22.04 테스트 환경에 오신 것을 환영합니다!
+
+          ## 접속 방법:
+          kubectl exec -it deploy/[release-name]-test-environment-test -- bash
+
+          ## 사용 가능한 도구:
+          - bash, sh
+          - python3
+          - 기본 Linux 유틸리티
+
+          ## 도구 설치:
+          /scripts/install-tools.sh 실행
+
+          ## 예제 스크립트:
+          - /scripts/test-db-connection.sh
+          - /scripts/test-api-call.sh
+          - /scripts/test-file-operations.sh
+
+        install-tools.sh: |
+          #!/bin/bash
+          echo "=== 유용한 도구 설치 중... ==="
+
+          apt-get update > /dev/null 2>&1
+          apt-get install -y \
+            curl \
+            wget \
+            vim \
+            net-tools \
+            dnsutils \
+            postgresql-client \
+            mysql-client \
+            redis-tools \
+            jq \
+            git \
+            python3-pip \
+            htop > /dev/null 2>&1
+
+          echo "✅ 도구 설치 완료!"
+          echo ""
+          echo "설치된 도구:"
+          echo "- curl, wget: HTTP 클라이언트"
+          echo "- vim: 텍스트 에디터"
+          echo "- postgresql-client: PostgreSQL 클라이언트"
+          echo "- mysql-client: MySQL 클라이언트"
+          echo "- redis-tools: Redis 클라이언트"
+          echo "- jq: JSON 처리기"
+          echo "- python3-pip: Python 패키지 관리자"
+
+        test-db-connection.sh: |
+          #!/bin/bash
+          echo "=== 데이터베이스 연결 테스트 ==="
+          echo "PostgreSQL 연결 테스트 예제:"
+          echo "psql \$DATABASE_URL -c 'SELECT version();'"
+          echo ""
+          echo "MySQL 연결 테스트 예제:"
+          echo "mysql -h \$DB_HOST -u \$DB_USER -p\$DB_PASSWORD -e 'SELECT VERSION();'"
+          echo ""
+          echo "Redis 연결 테스트 예제:"
+          echo "redis-cli -h \$REDIS_HOST ping"
+          echo ""
+          echo "환경변수를 설정하고 실제 명령을 실행하세요."
+
+        test-api-call.sh: |
+          #!/bin/bash
+          echo "=== API 호출 테스트 ==="
+          echo "HTTP GET 요청 예제:"
+          echo "curl -s https://httpbin.org/get | jq"
+          echo ""
+          echo "HTTP POST 요청 예제:"
+          echo "curl -s -X POST -H 'Content-Type: application/json' \\"
+          echo "  -d '{\"key\": \"value\"}' \\"
+          echo "  https://httpbin.org/post | jq"
+          echo ""
+          echo "실제 API 엔드포인트로 테스트해보세요."
+
+        test-file-operations.sh: |
+          #!/bin/bash
+          echo "=== 파일 작업 테스트 ==="
+          echo "작업 디렉토리: $(pwd)"
+          echo "디스크 사용량:"
+          df -h
+          echo ""
+          echo "메모리 사용량:"
+          free -h
+          echo ""
+          echo "임시 파일 생성 테스트:"
+          echo "Hello from Quick-CronJob!" > /tmp/test.txt
+          cat /tmp/test.txt
+          rm /tmp/test.txt
+          echo "✅ 파일 작업 테스트 완료"
+
+    # 테스트 Deployment 활성화
+    testDeployment:
+      enabled: true
+      installTools: false  # 수동 설치로 변경
+      welcomeMessage: |
+        ========================================
+        Quick-CronJob 테스트 환경에 오신 것을 환영합니다!
+        ========================================
+
+        🐧 Ubuntu 22.04 개발 환경
+
+        빠른 시작:
+        1. 도구 설치: /scripts/install-tools.sh
+        2. 예제 스크립트 확인: ls /scripts/
+        3. 문서 읽기: cat /scripts/README.md
+
+        CronJob 스크립트를 테스트하고 개발하세요!
+        ========================================

--- a/helm-charts/quick-cronjob/values.yaml.example
+++ b/helm-charts/quick-cronjob/values.yaml.example
@@ -1,0 +1,517 @@
+########################################################
+# Global Configuration
+########################################################
+global:
+  imageRegistry: ""                    # Global image registry (e.g., "docker.io", "gcr.io")
+  imagePullSecrets: []                 # Global image pull secrets
+    # - name: dockerhub-secret
+  timezone: "Asia/Seoul"               # Default timezone for all CronJobs
+  storageClass: ""                     # Default storage class
+
+########################################################
+# Multiple CronJobs Examples
+########################################################
+jobs:
+  # ===========================================
+  # Example 1: Database Backup Job
+  # ===========================================
+  postgres-backup:
+    enabled: true
+
+    # Schedule: Every day at 3 AM
+    schedule: "0 3 * * *"
+    timeZone: "Asia/Seoul"
+
+    # Job lifecycle
+    ttlSecondsAfterFinished: 86400     # Delete after 24 hours
+    activeDeadlineSeconds: 3600        # 1 hour timeout
+    backoffLimit: 3
+
+    # PostgreSQL image
+    image:
+      repository: postgres
+      tag: "14"
+      pullPolicy: IfNotPresent
+
+    # Environment variables
+    env:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: postgres-secret
+            key: password
+      - name: DATABASE_URL
+        value: "postgresql://user@postgres:5432/mydb"
+      - name: S3_BUCKET
+        value: "my-backup-bucket"
+
+    # Backup scripts in ConfigMap
+    configMap:
+      create: true
+      data:
+        backup.sh: |
+          #!/bin/bash
+          set -e
+
+          TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+          BACKUP_FILE="/backup/db_${TIMESTAMP}.sql"
+
+          echo "Starting PostgreSQL backup at ${TIMESTAMP}"
+
+          # Create backup
+          pg_dump ${DATABASE_URL} > ${BACKUP_FILE}
+
+          # Compress
+          gzip ${BACKUP_FILE}
+
+          # Upload to S3 (requires aws-cli)
+          if [ -n "${S3_BUCKET}" ]; then
+            aws s3 cp ${BACKUP_FILE}.gz s3://${S3_BUCKET}/postgres/
+            echo "Backup uploaded to S3"
+          fi
+
+          # Clean old backups (keep 7 days)
+          find /backup -name "*.gz" -mtime +7 -delete
+
+          echo "Backup completed successfully"
+
+    # Storage for backups
+    persistence:
+      enabled: true
+      size: "100Gi"
+      storageClassName: "fast-ssd"
+      mountPath: "/backup"
+
+    # ServiceAccount with S3 access (AWS)
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/backup-role"
+
+    # Run backup script
+    command: ["/bin/bash"]
+    args: ["/scripts/backup.sh"]
+
+    # Resources
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "1Gi"
+
+    # Test mode for development
+    testDeployment:
+      enabled: true
+      installTools: true
+
+  # ===========================================
+  # Example 2: Kubernetes Cluster Cleanup
+  # ===========================================
+  cluster-cleanup:
+    enabled: true
+
+    # Schedule: Every day at 2 AM
+    schedule: "0 2 * * *"
+    timeZone: "UTC"
+
+    # kubectl image
+    image:
+      repository: bitnami/kubectl
+      tag: "latest"
+      pullPolicy: Always
+
+    # ServiceAccount for cluster access
+    serviceAccount:
+      create: true
+
+    # Cluster permissions for cleanup
+    clusterRole:
+      create: true
+      rules:
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list", "delete"]
+        - apiGroups: ["batch"]
+          resources: ["jobs", "cronjobs"]
+          verbs: ["get", "list", "delete"]
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs: ["get", "list", "delete"]
+
+    # Cleanup scripts
+    configMap:
+      create: true
+      data:
+        cleanup.sh: |
+          #!/bin/bash
+
+          echo "=== Kubernetes Cluster Cleanup ==="
+          echo "Date: $(date)"
+
+          # 1. Clean evicted pods
+          echo "Cleaning evicted pods..."
+          kubectl get pods --all-namespaces -o json | \
+            jq -r '.items[] | select(.status.reason=="Evicted") |
+            "\(.metadata.namespace) \(.metadata.name)"' | \
+            while read ns pod; do
+              echo "Deleting evicted pod: $ns/$pod"
+              kubectl delete pod -n $ns $pod
+            done
+
+          # 2. Clean completed jobs older than 7 days
+          echo "Cleaning old completed jobs..."
+          kubectl get jobs --all-namespaces -o json | \
+            jq -r '.items[] | select(.status.completionTime != null) |
+            select(.status.completionTime | fromdateiso8601 < (now - 604800)) |
+            "\(.metadata.namespace) \(.metadata.name)"' | \
+            while read ns job; do
+              echo "Deleting old job: $ns/$job"
+              kubectl delete job -n $ns $job
+            done
+
+          # 3. Clean old events (older than 1 hour)
+          echo "Cleaning old events..."
+          kubectl get events --all-namespaces \
+            --field-selector="lastTimestamp<$(date -d '1 hour ago' -Iseconds)" \
+            -o name | xargs -r kubectl delete
+
+          echo "Cleanup completed"
+
+        report.sh: |
+          #!/bin/bash
+
+          echo "=== Cluster Status Report ==="
+          echo "Generated: $(date)"
+          echo ""
+
+          echo "Node Status:"
+          kubectl get nodes -o wide
+          echo ""
+
+          echo "Resource Usage:"
+          kubectl top nodes 2>/dev/null || echo "Metrics not available"
+          echo ""
+
+          echo "Problematic Pods:"
+          kubectl get pods --all-namespaces | grep -v Running | grep -v Completed
+          echo ""
+
+          echo "Disk Usage by Namespace:"
+          kubectl get pvc --all-namespaces
+
+    command: ["/bin/bash"]
+    args: ["/scripts/cleanup.sh"]
+
+    # Test mode
+    testDeployment:
+      enabled: true
+
+  # ===========================================
+  # Example 3: Data Processing ETL Job
+  # ===========================================
+  etl-processor:
+    enabled: true
+
+    # Schedule: Every 30 minutes
+    schedule: "*/30 * * * *"
+
+    # Python image
+    image:
+      repository: python
+      tag: "3.11-slim"
+      pullPolicy: IfNotPresent
+
+    # Environment variables
+    env:
+      - name: SOURCE_DB
+        value: "postgresql://user:pass@source-db:5432/data"
+      - name: TARGET_DB
+        value: "postgresql://user:pass@target-db:5432/warehouse"
+      - name: BATCH_SIZE
+        value: "1000"
+
+    # ETL scripts and requirements
+    configMap:
+      create: true
+      data:
+        requirements.txt: |
+          pandas==2.0.3
+          sqlalchemy==2.0.19
+          psycopg2-binary==2.9.7
+          redis==4.6.0
+          boto3==1.28.25
+
+        etl.py: |
+          import pandas as pd
+          import sqlalchemy
+          import os
+          import sys
+          from datetime import datetime, timedelta
+
+          def extract():
+              """Extract data from source database"""
+              print("Extracting data...")
+              engine = sqlalchemy.create_engine(os.environ['SOURCE_DB'])
+
+              # Get data from last hour
+              query = """
+              SELECT * FROM transactions
+              WHERE created_at >= %s
+              """
+              cutoff = datetime.now() - timedelta(hours=1)
+              df = pd.read_sql(query, engine, params=[cutoff])
+              print(f"Extracted {len(df)} records")
+              return df
+
+          def transform(df):
+              """Transform data"""
+              print("Transforming data...")
+
+              # Clean data
+              df = df.dropna()
+              df = df[df['amount'] > 0]
+
+              # Add processing timestamp
+              df['processed_at'] = datetime.now()
+
+              # Calculate derived fields
+              df['amount_usd'] = df['amount'] * df['exchange_rate']
+
+              print(f"Transformed to {len(df)} clean records")
+              return df
+
+          def load(df):
+              """Load data to target database"""
+              print("Loading data...")
+              engine = sqlalchemy.create_engine(os.environ['TARGET_DB'])
+
+              df.to_sql(
+                  'processed_transactions',
+                  engine,
+                  if_exists='append',
+                  index=False,
+                  chunksize=int(os.environ.get('BATCH_SIZE', 1000))
+              )
+              print(f"Loaded {len(df)} records to warehouse")
+
+          def main():
+              try:
+                  print(f"Starting ETL process at {datetime.now()}")
+
+                  # ETL pipeline
+                  data = extract()
+                  if len(data) == 0:
+                      print("No new data to process")
+                      return
+
+                  data = transform(data)
+                  load(data)
+
+                  print("ETL process completed successfully")
+
+              except Exception as e:
+                  print(f"ETL process failed: {str(e)}")
+                  sys.exit(1)
+
+          if __name__ == "__main__":
+              main()
+
+        entrypoint.sh: |
+          #!/bin/bash
+          set -e
+
+          echo "Installing Python dependencies..."
+          pip install --no-cache-dir -r /scripts/requirements.txt
+
+          echo "Starting ETL process..."
+          python /scripts/etl.py
+
+    command: ["/bin/bash"]
+    args: ["/scripts/entrypoint.sh"]
+
+    # Resources for data processing
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi"
+
+    # Test mode
+    testDeployment:
+      enabled: true
+      installTools: true
+
+  # ===========================================
+  # Example 4: Log Rotation and Cleanup
+  # ===========================================
+  log-cleanup:
+    enabled: false                     # Disabled by default
+
+    # Schedule: Every Sunday at 1 AM
+    schedule: "0 1 * * 0"
+
+    # Alpine with common tools
+    image:
+      repository: alpine
+      tag: "3.18"
+      pullPolicy: IfNotPresent
+
+    # Cleanup configuration
+    env:
+      - name: LOG_RETENTION_DAYS
+        value: "30"
+      - name: MAX_LOG_SIZE_MB
+        value: "100"
+
+    configMap:
+      create: true
+      data:
+        install-tools.sh: |
+          #!/bin/sh
+          apk add --no-cache \
+            curl \
+            jq \
+            findutils \
+            gzip \
+            tar
+
+        log-cleanup.sh: |
+          #!/bin/sh
+
+          echo "=== Log Cleanup Process ==="
+
+          # Install required tools
+          /scripts/install-tools.sh
+
+          # Find and compress old logs
+          find /logs -name "*.log" -mtime +7 -type f | while read logfile; do
+            echo "Compressing: $logfile"
+            gzip "$logfile"
+          done
+
+          # Remove very old compressed logs
+          find /logs -name "*.gz" -mtime +${LOG_RETENTION_DAYS:-30} -delete
+
+          # Clean large log files
+          find /logs -name "*.log" -size +${MAX_LOG_SIZE_MB:-100}M | while read largefile; do
+            echo "Truncating large file: $largefile"
+            tail -n 1000 "$largefile" > "${largefile}.tmp"
+            mv "${largefile}.tmp" "$largefile"
+          done
+
+          echo "Log cleanup completed"
+
+    # Mount logs volume
+    persistence:
+      enabled: true
+      size: "50Gi"
+      mountPath: "/logs"
+
+    command: ["/bin/sh"]
+    args: ["/scripts/log-cleanup.sh"]
+
+    # Test mode
+    testDeployment:
+      enabled: false
+
+  # ===========================================
+  # Default Test Environment (Always Enabled)
+  # ===========================================
+  test-environment:
+    enabled: true
+
+    # Never actually run as CronJob
+    schedule: "0 0 31 2 *"  # February 31st = never
+    suspend: true
+
+    # Ubuntu test environment
+    image:
+      repository: ubuntu
+      tag: "22.04"
+      pullPolicy: IfNotPresent
+
+    # Test scripts and documentation
+    configMap:
+      create: true
+      data:
+        README.md: |
+          # Quick-CronJob Examples
+
+          이 환경에서 위의 모든 예제를 테스트할 수 있습니다.
+
+          ## 접속 방법:
+          kubectl exec -it deploy/[release-name]-test-environment-test -- bash
+
+          ## 예제 테스트:
+          1. /scripts/test-db-backup.sh      # DB 백업 테스트
+          2. /scripts/test-kubectl.sh        # kubectl 명령 테스트
+          3. /scripts/test-python-etl.sh     # Python ETL 테스트
+
+          ## 도구 설치:
+          /scripts/install-all-tools.sh
+
+        install-all-tools.sh: |
+          #!/bin/bash
+          echo "=== Installing comprehensive toolset ==="
+
+          apt-get update
+          apt-get install -y \
+            curl wget vim nano \
+            net-tools dnsutils iputils-ping \
+            postgresql-client mysql-client redis-tools \
+            python3 python3-pip \
+            nodejs npm \
+            git jq yq \
+            htop tree \
+            unzip zip \
+            awscli
+
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+
+          echo "✅ All tools installed!"
+
+        test-db-backup.sh: |
+          #!/bin/bash
+          echo "=== Database Backup Test ==="
+          echo "1. Check PostgreSQL client:"
+          pg_dump --version
+
+          echo "2. Test connection (set DATABASE_URL first):"
+          echo "   export DATABASE_URL='postgresql://user:pass@host:5432/db'"
+          echo "   pg_dump \$DATABASE_URL --schema-only"
+
+        test-kubectl.sh: |
+          #!/bin/bash
+          echo "=== Kubectl Test ==="
+          echo "1. Check kubectl:"
+          kubectl version --client
+
+          echo "2. Test cluster access:"
+          kubectl get nodes
+
+          echo "3. Test permissions:"
+          kubectl auth can-i get pods
+
+        test-python-etl.sh: |
+          #!/bin/bash
+          echo "=== Python ETL Test ==="
+          echo "1. Check Python:"
+          python3 --version
+
+          echo "2. Install common packages:"
+          pip3 install pandas sqlalchemy psycopg2-binary
+
+          echo "3. Test imports:"
+          python3 -c "import pandas, sqlalchemy; print('✅ ETL packages ready')"
+
+    # Always enable test deployment
+    testDeployment:
+      enabled: true
+      installTools: false  # Manual installation with comprehensive tools


### PR DESCRIPTION
## Summary
- Implements quick-cronjob Helm chart following quick-deploy patterns
- Supports multiple CronJobs with individual configuration per job
- Test deployment mode for live debugging and testing
- Modern Kubernetes CronJob features (timezone, suspend, TTL)

## Key Features
- **Multi-job support**: Range iteration for managing multiple CronJobs
- **Test deployment mode**: Sleep containers with same environment as CronJob for debugging
- **Modern K8s features**: timezone, ttlSecondsAfterFinished, suspend
- **RBAC support**: ServiceAccount, ClusterRole, ClusterRoleBinding for kubectl access
- **ConfigMap inline data**: Direct definition in values.yaml like quick-deploy
- **PVC support**: Persistent storage for job data
- **Default test environment**: Ubuntu 22.04 with helpful scripts

## Test Plan
- [x] Helm lint passes
- [x] Templates render correctly
- [x] Default values provide working Ubuntu test environment
- [x] RBAC templates for kubectl access
- [x] ConfigMap with useful development scripts

## Files Added
- Chart.yaml: Chart metadata
- values.yaml: Default Ubuntu 22.04 test environment
- values.yaml.example: Comprehensive examples (postgres-backup, ETL, etc.)
- templates/: All K8s resource templates
- .helmignore: Standard Helm ignore patterns

🤖 Generated with [Claude Code](https://claude.ai/code)