### PR TITLE
feat: graceful-demo 컨테이너 추가

### DIFF
--- a/containers/graceful-demo/Dockerfile
+++ b/containers/graceful-demo/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN CGO_ENABLED=0 go build -o graceful-demo .
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /app/graceful-demo /usr/local/bin/graceful-demo
+ENTRYPOINT ["graceful-demo"]

--- a/containers/graceful-demo/README.md
+++ b/containers/graceful-demo/README.md
@@ -1,0 +1,95 @@
+# graceful-demo
+
+K8s 파드 종료 시 graceful shutdown 실험을 위한 데모 HTTP 서버.
+
+## 엔드포인트
+
+| 경로 | 설명 |
+|------|------|
+| `GET /` | 즉시 200 응답. 파드 이름과 시각 반환 |
+| `GET /slow?ms=N` | N밀리초 후 200 응답. 처리 중 종료 재현용 (기본 3000ms) |
+| `GET /health` | readiness/liveness probe용 |
+
+## 환경변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `GRACEFUL` | `false` | `true`: SIGTERM 시 기존 요청 마무리 후 종료. `false`: 즉시 종료 |
+| `POD_NAME` | `unknown` | 응답/로그에 표시할 파드 이름. `fieldRef: metadata.name`으로 주입 |
+
+## 실험 시나리오
+
+4가지 조합으로 롤링 배포 중 5xx 발생 여부를 비교한다.
+
+| | preStop 없음 | preStop: sleep 5 |
+|---|---|---|
+| **GRACEFUL=false** | 5xx 많음 | 5xx 줄어듦 (처리 중이던 건 실패) |
+| **GRACEFUL=true** | 5xx 일부 (새 요청이 죽어가는 파드로) | 5xx 없음 |
+
+## 로컬 테스트
+
+```bash
+docker build -t graceful-demo .
+docker run -p 8080:8080 -e GRACEFUL=true -e POD_NAME=local graceful-demo
+```
+
+## K8s 배포 예시
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: graceful-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: graceful-demo
+  template:
+    metadata:
+      labels:
+        app: graceful-demo
+    spec:
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: demo
+          image: cagojeiger/graceful-demo:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: GRACEFUL
+              value: "true"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graceful-demo
+spec:
+  selector:
+    app: graceful-demo
+  ports:
+    - port: 80
+      targetPort: 8080
+```
+
+## 부하 테스트
+
+```bash
+# 별도 파드에서 지속적으로 요청
+kubectl run loadgen --image=busybox --rm -it -- sh -c \
+  'while true; do wget -qO- --timeout=2 http://graceful-demo/slow?ms=1000 || echo "FAIL $(date)"; done'
+```

--- a/containers/graceful-demo/go.mod
+++ b/containers/graceful-demo/go.mod
@@ -1,0 +1,3 @@
+module graceful-demo
+
+go 1.24

--- a/containers/graceful-demo/main.go
+++ b/containers/graceful-demo/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	graceful := strings.ToLower(os.Getenv("GRACEFUL")) == "true"
+	podName := os.Getenv("POD_NAME")
+	if podName == "" {
+		podName = "unknown"
+	}
+
+	mux := http.NewServeMux()
+
+	// 즉시 응답 — 어떤 파드가 응답했는지 확인용
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, "pod=%s time=%s\n", podName, time.Now().Format(time.RFC3339Nano))
+	})
+
+	// 지연 응답 — 처리 중 종료 재현용
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		ms, _ := strconv.Atoi(r.URL.Query().Get("ms"))
+		if ms <= 0 {
+			ms = 3000
+		}
+		log.Printf("[REQ] /slow?ms=%d started on %s", ms, podName)
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+		fmt.Fprintf(w, "pod=%s delayed=%dms\n", podName, ms)
+		log.Printf("[REQ] /slow?ms=%d completed on %s", ms, podName)
+	})
+
+	// probe용
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	// SIGTERM 핸들링
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		sig := <-sigCh
+		log.Printf("[SHUTDOWN] signal=%s graceful=%v pod=%s time=%s",
+			sig, graceful, podName, time.Now().Format(time.RFC3339Nano))
+
+		if !graceful {
+			log.Println("[SHUTDOWN] ungraceful — exiting immediately")
+			os.Exit(0)
+		}
+
+		// graceful shutdown: 새 연결 거부 + 기존 요청 마무리
+		log.Println("[SHUTDOWN] graceful — draining connections")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("[SHUTDOWN] error: %v", err)
+		}
+		log.Println("[SHUTDOWN] graceful shutdown complete")
+	}()
+
+	log.Printf("[START] pod=%s graceful=%v addr=:8080", podName, graceful)
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("[FATAL] %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- K8s 파드 graceful shutdown 실험용 Go HTTP 서버
- 환경변수 `GRACEFUL=true/false`로 종료 모드 전환
- 엔드포인트: `/` (즉시), `/slow?ms=N` (지연), `/health` (probe)
- 머지 시 DockerHub에 `cagojeiger/graceful-demo:latest` 자동 배포

## 용도
블로그 글 "K8s 파드 종료 시 네트워크 경쟁 조건" 실험에 사용

## Test plan
- [x] 로컬 Docker 빌드 성공
- [x] 3개 엔드포인트 정상 동작 확인
- [x] SIGTERM graceful shutdown 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)