### PR TITLE
fix: graceful shutdown drain 완료까지 main 대기

### DIFF
--- a/containers/graceful-demo/main.go
+++ b/containers/graceful-demo/main.go
@@ -66,6 +66,8 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
+	shutdownDone := make(chan struct{})
+
 	go func() {
 		sig := <-sigCh
 		log.Printf("[SHUTDOWN] signal=%s graceful=%v pod=%s time=%s",
@@ -84,10 +86,16 @@ func main() {
 			log.Printf("[SHUTDOWN] error: %v", err)
 		}
 		log.Println("[SHUTDOWN] graceful shutdown complete")
+		close(shutdownDone)
 	}()
 
 	log.Printf("[START] pod=%s graceful=%v addr=:8080", podName, graceful)
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("[FATAL] %v", err)
+	}
+
+	// graceful shutdown이 끝날 때까지 main 대기 (in-flight 요청 drain 보장)
+	if graceful {
+		<-shutdownDone
 	}
 }


### PR DESCRIPTION
## Summary
- `srv.Shutdown()`이 goroutine에서 실행되는데 `ListenAndServe()`가 즉시 return하면서 main이 먼저 종료되는 race condition 수정
- `shutdownDone` 채널로 main이 drain 완료를 대기하도록 변경

## Background
graceful shutdown 실험 중 in-flight 요청이 drain 되지 않고 killed되는 현상 발견. 원인 분석 결과 main()이 Shutdown() 완료를 기다리지 않고 exit하는 버그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)