### PR TITLE
feat(quick-deploy): add terminationGracePeriodSeconds support (v0.1.17)

### DIFF
--- a/helm-charts/quick-deploy/Chart.yaml
+++ b/helm-charts/quick-deploy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Rapid multi-application deployment template for Kubernetes
 name: quick-deploy
 type: application
-version: 0.1.16
+version: 0.1.17
 keywords:
   - deployment
   - multi-app

--- a/helm-charts/quick-deploy/templates/deployment.yaml
+++ b/helm-charts/quick-deploy/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       {{- if and $app.serviceAccount $app.serviceAccount.create }}
       serviceAccountName: {{ include "quick-deploy.serviceAccountName" (dict "root" $ "name" $name "app" $app) }}
       {{- end }}
+      {{- with $app.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with $app.podSecurityContext | default $app.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/quick-deploy/values.schema.json
+++ b/helm-charts/quick-deploy/values.schema.json
@@ -422,6 +422,10 @@
               "type": "object"
             }
           },
+          "terminationGracePeriodSeconds": {
+            "type": "integer",
+            "description": "Grace period in seconds before K8s force-kills the pod on termination. Must be >= preStop sleep + application graceful drain budget + safety buffer."
+          },
           "imagePullSecrets": {
             "type": "array",
             "description": "Image pull secrets",

--- a/helm-charts/quick-deploy/values.yaml.example
+++ b/helm-charts/quick-deploy/values.yaml.example
@@ -222,6 +222,11 @@ apps:
         memory: 128Mi                  # Memory request
         ephemeral-storage: 100Mi       # Ephemeral storage request
 
+    # Grace period before K8s force-kills the pod on termination.
+    # Must be >= preStop sleep + application graceful drain budget + buffer.
+    # Default K8s value is 30s; raise it for services with long in-flight work.
+    terminationGracePeriodSeconds: 60
+
     # Container lifecycle hooks
     lifecycle:
       preStop:                         # Execute before container stops


### PR DESCRIPTION
## Summary

quick-deploy 차트에서 pod의 `terminationGracePeriodSeconds`를 설정할 수 있게 추가합니다.

K8s 기본값 30초는 긴 in-flight 작업(백그라운드 스케줄러, 대용량 HTTP 요청)을 처리하는 서비스에서 짧을 수 있습니다. preStop sleep + 앱 graceful drain 시간을 합쳐도 충분한 여유를 주려면 이 값을 올려야 합니다.

## Why

feedgate-fetcher에서 graceful shutdown을 적용하려는데:
- `preStop sleep 5s` (iptables propagation용)
- `shutdown_drain_seconds 90s` (in-flight tick 완료용)
- 합계 95s → 기본 30s 안에 못 끝남 → SIGKILL로 tick 중단

`lifecycle.preStop`은 차트가 이미 지원하지만 `terminationGracePeriodSeconds`는 없어서 values로 설정이 불가능했습니다.

## Changes

- `templates/deployment.yaml`: pod spec 레벨에 렌더링 추가 (`serviceAccountName` 다음 줄)
- `values.schema.json`: 스키마 정의 (integer, `tolerations` 옆에 배치)
- `values.yaml.example`: `lifecycle` 섹션 바로 위에 예시 추가
- `Chart.yaml`: 0.1.16 → 0.1.17

## Test plan

- [x] `helm lint` — pass
- [x] `helm template`로 렌더링 검증 — `terminationGracePeriodSeconds: 120`이 pod spec에 정상 출력됨

## 사용 예시

```yaml
apps:
  my-service:
    terminationGracePeriodSeconds: 120
    lifecycle:
      preStop:
        exec:
          command: ["sh", "-c", "sleep 5"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)