### PR TITLE
feat(quick-deploy): add enableServiceLinks passthrough (v0.1.18)

### DIFF
--- a/helm-charts/quick-deploy/Chart.yaml
+++ b/helm-charts/quick-deploy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.0
 description: Rapid multi-application deployment template for Kubernetes
 name: quick-deploy
 type: application
-version: 0.1.17
+version: 0.1.18
 keywords:
   - deployment
   - multi-app

--- a/helm-charts/quick-deploy/templates/deployment.yaml
+++ b/helm-charts/quick-deploy/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if hasKey $app "enableServiceLinks" }}
+      enableServiceLinks: {{ $app.enableServiceLinks }}
+      {{- end }}
       {{- with $.Values.global.imagePullSecrets | default $app.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## 변경 내용

`apps.<name>.enableServiceLinks` 를 Deployment 의 pod spec 으로 패스스루합니다.

```yaml
spec:
  {{- if hasKey $app "enableServiceLinks" }}
  enableServiceLinks: {{ $app.enableServiceLinks }}
  {{- end }}
```

- 미지정 시 렌더되지 않아 **기존 동작(기본 true) 그대로 보존** (하위호환).
- Chart version `0.1.17` → `0.1.18`.

## 왜 필요한가

앱이 env prefix(예: `OPSGATE_`)로 **strict config 파싱**을 할 때, 동명 Service(`opsgate`)가 있으면 쿠버네티스가 `OPSGATE_PORT_9091_TCP`, `OPSGATE_SERVICE_HOST` 같은 **service-link env 를 자동 주입** → 앱이 모르는 설정 필드로 보고 크래시합니다. `enableServiceLinks: false` 로 이 주입을 끄면 해결됩니다.

실제 사례: opsgate v0.1.1 배포 시 `configuration error: unknown field port_9091_tcp` 로 CrashLoopBackOff.

## 검증

- `helm template ... --set apps.x.enableServiceLinks=false` → Deployment 에 `enableServiceLinks: false` 렌더 확인
- 미지정 시 미렌더 확인 (하위호환)
- `helm lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)